### PR TITLE
Updated to v0.9.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.7" %}
+{% set version = "0.9.8" %}
 
 package:
   name: hyperion
@@ -7,7 +7,7 @@ package:
 source:
   fn: Hyperion-{{version}}.tar.gz
   url: https://pypi.io/packages/source/h/hyperion/Hyperion-{{version}}.tar.gz
-  md5: 9ab9f0341d83a2c7a1d996e7438ba8d0
+  md5: 970ebfa8b65c4a181fcdd788ee71dd38
 
 build:
   number: 1
@@ -22,7 +22,7 @@ requirements:
     - numpy x.x
 
   run:
-    - hyperion-fortran
+    - hyperion-fortran 0.9.8
     - python
     - numpy x.x
     - matplotlib


### PR DESCRIPTION
I've now pinned the dependency on hyperion-fortran to a specific version because the two should always stay in sync.